### PR TITLE
return ErrBadConn upon connection errors

### DIFF
--- a/column.go
+++ b/column.go
@@ -64,7 +64,7 @@ loop:
 			break loop
 		case C.SQL_SUCCESS_WITH_INFO:
 			err := formatError(C.SQL_HANDLE_STMT, C.SQLHANDLE(c.h))
-			if err.SQLState() != "01004" {
+			if cliErr, ok := err.(*cliError); ok && cliErr.SQLState() != "01004" {
 				return nil, err
 			}
 			// buf is not big enough; data has been truncated

--- a/column.go
+++ b/column.go
@@ -64,7 +64,7 @@ loop:
 			break loop
 		case C.SQL_SUCCESS_WITH_INFO:
 			err := formatError(C.SQL_HANDLE_STMT, C.SQLHANDLE(c.h))
-			if cliErr, ok := err.(*cliError); ok && cliErr.SQLState() != "01004" {
+			if cliErr, ok := err.(*cliError); !ok || cliErr.SQLState() != "01004" {
 				return nil, err
 			}
 			// buf is not big enough; data has been truncated


### PR DESCRIPTION
The database driver is expected to return the error "ErrBadConn" in some scenarios as described here:
https://golang.org/src/database/sql/driver/driver.go

ErrBadConn is used by the sql package to remove the bad connection from the connection pool (and possibly retry on a new connection) as seen here: https://golang.org/src/database/sql/sql.go

If the driver does not return ErrBadConn, then in some scenarios, the sql package is unable to prune the bad connection from the connection pool. As a result the application keeps receiving errors from the sql library due to the usage of the bad connection, even though a new connection to the database works.

fixes issue: #14 